### PR TITLE
Updates for UART support

### DIFF
--- a/svd/patches/_dport_peri.yaml
+++ b/svd/patches/_dport_peri.yaml
@@ -1,0 +1,201 @@
+DPORT:
+  PERI_CLK_EN:
+    _add:
+        DIGITAL_SIGNATURE:
+          bitOffset: 4
+          bitWidth: 1
+        SECURE_BOOT:
+          bitOffset: 3
+          bitWidth: 1
+        RSA_ACCELERATOR:
+          bitOffset: 2
+          bitWidth: 1
+        SHA_ACCELERATOR:
+          bitOffset: 1
+          bitWidth: 1
+        AES_ACCELERATOR:
+          bitOffset: 0
+          bitWidth: 1
+  PERI_RST_EN:
+    _add:
+        DIGITAL_SIGNATURE:
+          bitOffset: 4
+          bitWidth: 1
+        SECURE_BOOT:
+          bitOffset: 3
+          bitWidth: 1
+        RSA_ACCELERATOR:
+          bitOffset: 2
+          bitWidth: 1
+        SHA_ACCELERATOR:
+          bitOffset: 1
+          bitWidth: 1
+        AES_ACCELERATOR:
+          bitOffset: 0
+          bitWidth: 1
+  PERIP_CLK_EN:
+    _add:
+        PWM3:
+          bitOffset: 26
+          bitWidth: 1
+        PWM2:
+          bitOffset: 25
+          bitWidth: 1
+        UART_MEM:
+          bitOffset: 24
+          bitWidth: 1
+        UART2:
+          bitOffset: 23
+          bitWidth: 1
+        SPI_DMA:
+          bitOffset: 22
+          bitWidth: 1
+        I2S1:
+          bitOffset: 21
+          bitWidth: 1
+        PWM1:
+          bitOffset: 20
+          bitWidth: 1
+        CAN:
+          bitOffset: 19
+          bitWidth: 1
+        I2C1:
+          bitOffset: 18
+          bitWidth: 1
+        PWM0:
+          bitOffset: 17
+          bitWidth: 1
+        SPI3:
+          bitOffset: 16
+          bitWidth: 1
+        TIMER_GROUP1:
+          bitOffset: 15
+          bitWidth: 1
+        EFUSE:
+          bitOffset: 14
+          bitWidth: 1
+        TIMER_GROUP0:
+          bitOffset: 13
+          bitWidth: 1
+        UHCI1:
+          bitOffset: 12
+          bitWidth: 1
+        LED_PWM:
+          bitOffset: 11
+          bitWidth: 1
+        PULSE_CNT:
+          bitOffset: 10
+          bitWidth: 1
+        REMOTE_CONTROLLER:
+          bitOffset: 9
+          bitWidth: 1
+        UHCI0:
+          bitOffset: 8
+          bitWidth: 1
+        I2C0:
+          bitOffset: 7
+          bitWidth: 1
+        SPI2:
+          bitOffset: 6
+          bitWidth: 1
+        UART1:
+          bitOffset: 5
+          bitWidth: 1
+        I2S0:
+          bitOffset: 4
+          bitWidth: 1
+        WDG:
+          bitOffset: 3
+          bitWidth: 1
+        UART0:
+          bitOffset: 2
+          bitWidth: 1
+        SPI0:
+          bitOffset: 1
+          bitWidth: 1
+        TIMERS:
+          bitOffset: 0
+          bitWidth: 1
+  PERIP_RST_EN:
+    _add:
+        PWM3:
+          bitOffset: 26
+          bitWidth: 1
+        PWM2:
+          bitOffset: 25
+          bitWidth: 1
+        UART_MEM:
+          bitOffset: 24
+          bitWidth: 1
+        UART2:
+          bitOffset: 23
+          bitWidth: 1
+        SPI_DMA:
+          bitOffset: 22
+          bitWidth: 1
+        I2S1:
+          bitOffset: 21
+          bitWidth: 1
+        PWM1:
+          bitOffset: 20
+          bitWidth: 1
+        CAN:
+          bitOffset: 19
+          bitWidth: 1
+        I2C1:
+          bitOffset: 18
+          bitWidth: 1
+        PWM0:
+          bitOffset: 17
+          bitWidth: 1
+        SPI3:
+          bitOffset: 16
+          bitWidth: 1
+        TIMER_GROUP1:
+          bitOffset: 15
+          bitWidth: 1
+        EFUSE:
+          bitOffset: 14
+          bitWidth: 1
+        TIMER_GROUP0:
+          bitOffset: 13
+          bitWidth: 1
+        UHCI1:
+          bitOffset: 12
+          bitWidth: 1
+        LED_PWM:
+          bitOffset: 11
+          bitWidth: 1
+        PULSE_CNT:
+          bitOffset: 10
+          bitWidth: 1
+        REMOTE_CONTROLLER:
+          bitOffset: 9
+          bitWidth: 1
+        UHCI0:
+          bitOffset: 8
+          bitWidth: 1
+        I2C0:
+          bitOffset: 7
+          bitWidth: 1
+        SPI2:
+          bitOffset: 6
+          bitWidth: 1
+        UART1:
+          bitOffset: 5
+          bitWidth: 1
+        I2S0:
+          bitOffset: 4
+          bitWidth: 1
+        WDG:
+          bitOffset: 3
+          bitWidth: 1
+        UART0:
+          bitOffset: 2
+          bitWidth: 1
+        SPI0:
+          bitOffset: 1
+          bitWidth: 1
+        TIMERS:
+          bitOffset: 0
+          bitWidth: 1

--- a/svd/patches/_uart.yaml
+++ b/svd/patches/_uart.yaml
@@ -1,0 +1,64 @@
+_modify:
+  UART:
+    addressBlocks:
+    - offset: 0x0
+      size: 0x400
+      usage: UART registers
+    - offset: 0x200C0000
+      size: 0x4
+      usage: TX FIFO
+
+UART:
+  _add:
+    TX_FIFO:
+      description: UART_TX_FIFO
+      addressOffset: 0x200C0000
+      size: 8
+      access: write-only
+    RX_FIFO:
+      description: UART_RX_FIFO
+      addressOffset: 0x00
+      size: 8
+      access: read-only
+  STATUS:
+    UART_ST_UTX_OUT:
+      TX_IDLE: [0, "TX_IDLE"]
+      TX_STRT: [1, "TX_STRT"]
+      TX_DAT0: [2, "TX_DAT0"]
+      TX_DAT1: [3, "TX_DAT1"]
+      TX_DAT2: [4, "TX_DAT2"]
+      TX_DAT3: [5, "TX_DAT3"]
+      TX_DAT4: [6, "TX_DAT4"]
+      TX_DAT5: [7, "TX_DAT5"]
+      TX_DAT6: [8, "TX_DAT6"]
+      TX_DAT7: [9, "TX_DAT7"]
+      TX_PRTY: [10, "TX_PRTY"]
+      TX_STP1: [11, "TX_STP1"]
+      TX_STP2: [12, "TX_STP2"]
+      TX_DL1: [13, "TX_DL0"]
+      TX_DL1: [14, "TX_DL1"]
+    UART_ST_URX_OUT:
+      RX_IDLE: [0, "RX_IDLE"]
+      RX_STRT: [1, "RX_STRT"]
+      RX_DAT0: [2, "RX_DAT0"]
+      RX_DAT1: [3, "RX_DAT1"]
+      RX_DAT2: [4, "RX_DAT2"]
+      RX_DAT3: [5, "RX_DAT3"]
+      RX_DAT4: [6, "RX_DAT4"]
+      RX_DAT5: [7, "RX_DAT5"]
+      RX_DAT6: [8, "RX_DAT6"]
+      RX_DAT7: [9, "RX_DAT7"]
+      RX_PRTY: [10, "RX_PRTY"]
+      RX_STP1: [11, "RX_STP1"]
+      RX_STP2: [12, "RX_STP2"]
+      RX_DL1: [13, "RX_DL1"]
+  CONF0:
+    UART_STOP_BIT_NUM:
+      STOP_BITS_1: [1, "1 stop bits"]
+      STOP_BITS_1p5: [2, "1.5 stop bits"]
+      STOP_BITS_2: [3, "2 stop bits"]
+    UART_BIT_NUM:
+      DATA_BITS_5: [0, "5 data bits"]
+      DATA_BITS_6: [1, "6 data bits"]
+      DATA_BITS_7: [2, "7 data bits"]
+      DATA_BITS_8: [3, "8 data bits"]

--- a/svd/patches/esp32.yaml
+++ b/svd/patches/esp32.yaml
@@ -2,6 +2,8 @@ _svd: ../esp32.base.svd
 
 
 _include:
+  - "_uart.yaml"
+  - "_dport_peri.yaml"
   - "_io_mux.yaml"
   - "_rename_registers.yaml"
   - "_rename_bitfields.yaml"


### PR DESCRIPTION
This prepares for UART support.
It also includes updates for the dport peripheral (used to enable/disable and reset peripherals).

It is depends on pull request for svdtools to support multiple addressblocks: https://github.com/stm32-rs/svdtools/pull/16