### PR TITLE
Revert indexed interrupts

### DIFF
--- a/svd/patches/_indexed_interrupts.yaml
+++ b/svd/patches/_indexed_interrupts.yaml
@@ -1,0 +1,203 @@
+
+
+TIMG0:
+  _add:
+    _interrupts:
+      TG0_T0_EDGE_INTR:
+        description: "interrupt of TIMER_GROUP0, TIMER0, EDGE"
+        value: 58
+      
+      TG0_T1_EDGE_INTR:
+        description: "interrupt of TIMER_GROUP0, TIMER1, EDGE"
+        value: 59
+      
+      TG0_WDT_EDGE_INTR:
+        description: "interrupt of TIMER_GROUP0, WATCH DOG, EDGE"
+        value: 60
+      
+      TG0_LACT_EDGE_INTR:
+        description: "interrupt of TIMER_GROUP0, LACT, EDGE"
+        value: 61
+      
+TIMG1:
+  _add:
+    _interrupts:      
+      TG1_T0_EDGE_INTR:
+        description: "interrupt of TIMER_GROUP1, TIMER0, EDGE"
+        value: 62
+      
+      TG1_T1_EDGE_INTR:
+        description: "interrupt of TIMER_GROUP1, TIMER1, EDGE"
+        value: 63
+      
+      TG1_WDT_EDGE_INTR:
+        description: "interrupt of TIMER_GROUP1, WATCHDOG, EDGE"
+        value: 64
+      
+      TG1_LACT_EDGE_INTR:
+        description: "interrupt of TIMER_GROUP0, LACT, EDGE"
+        value: 65
+
+SPI1:
+  _add:
+    _interrupts:      
+      SPI1_DMA_INTR:
+        description: "interrupt of SPI1 DMA, SPI1 is for flash read/write, do not use this"
+        value: 52
+
+SPI2:
+  _add:
+    _interrupts:      
+      SPI2_DMA_INTR:
+        description: "interrupt of SPI2 DMA, level"
+        value: 53
+      
+SPI3:
+  _add:
+    _interrupts:      
+      SPI3_DMA_INTR:
+        description: "interrupt of SPI3 DMA, level"
+        value: 54
+
+I2C0:
+  _add:
+    _interrupts:      
+      I2C_EXT0_INTR:
+        description: "interrupt of I2C controller0, level"
+        value: 49
+
+I2C1:
+  _add:
+    _interrupts:      
+      I2C_EXT1_INTR:
+        description: "interrupt of I2C controller1, level"
+        value: 50
+
+PWM0:
+  _add:
+    _interrupts:      
+      PWM0_INTR:
+        description: "interrupt of PWM0, level, Reserved"
+        value: 39
+
+PWM1:
+  _add:
+    _interrupts:      
+      PWM1_INTR:
+        description: "interrupt of PWM1, level, Reserved"
+        value: 40
+
+PWM2:
+  _add:
+    _interrupts:      
+      PWM2_INTR:
+        description: "interrupt of PWM2, level"
+        value: 41
+      
+PWM3:
+  _add:
+    _interrupts:      
+      PWM3_INTR:
+        description: "interrupt of PWM3, level"
+        value: 42
+
+UART0:
+  _add:
+    _interrupts:      
+      UART0_INTR:
+        description: "interrupt of UART0, level"
+        value: 34
+
+UART1:
+  _add:
+    _interrupts:      
+      UART1_INTR:
+        description: "interrupt of UART1, level"
+        value: 35
+
+UART2:
+  _add:
+    _interrupts:      
+      UART2_INTR:
+        description: "interrupt of UART2, level"
+        value: 36
+
+SPI0:
+  _add:
+    _interrupts:      
+      SPI0_INTR:
+        description: "interrupt of SPI0, level, SPI0 is for Cache Access, do not use this"
+        value: 28
+
+SPI1:
+  _add:
+    _interrupts:      
+      SPI1_INTR:
+        description: "interrupt of SPI1, level, SPI1 is for flash read/write, do not use this"
+        value: 29
+
+SPI2:
+  _add:
+    _interrupts:      
+      SPI2_INTR:
+        description: "interrupt of SPI2, level"
+        value: 30
+
+SPI3:
+  _add:
+    _interrupts:      
+      SPI3_INTR:
+        description: "interrupt of SPI3, level"
+        value: 31
+
+UHCI0:
+  _add:
+    _interrupts:
+      UHCI0_INTR:
+        description: "interrupt of UHCI0, level"
+        value: 12
+
+UHCI1:
+  _add:
+    _interrupts:
+      UHCI1_INTR:
+        description: "interrupt of UHCI1, level"
+        value: 13
+
+TIMG0:
+  _add:
+    _interrupts:
+      TG0_T0_LEVEL_INTR:
+        description: "interrupt of TIMER_GROUP0, TIMER0, level, we would like use EDGE for timer if permission"
+        value: 14
+
+      TG0_T1_LEVEL_INTR:
+        description: "interrupt of TIMER_GROUP0, TIMER1, level, we would like use EDGE for timer if permission"
+        value: 15
+
+      TG0_WDT_LEVEL_INTR:
+        description: "interrupt of TIMER_GROUP0, WATCHDOG, level"
+        value: 16
+
+      TG0_LACT_LEVEL_INTR:
+        description: "interrupt of TIMER_GROUP0, LACT, level"
+        value: 17
+
+TIMG1:
+  _add:
+    _interrupts:
+      TG1_T0_LEVEL_INTR:
+        description: "interrupt of TIMER_GROUP1, TIMER0, level, we would like use EDGE for timer if permission"
+        value: 18
+    
+      TG1_T1_LEVEL_INTR:
+        description: "interrupt of TIMER_GROUP1, TIMER1, level, we would like use EDGE for timer if permission"
+        value: 19
+
+      TG1_WDT_LEVEL_INTR:
+        description: "interrupt of TIMER_GROUP1, WATCHDOG, level"
+        value: 20
+    
+      TG1_LACT_LEVEL_INTR:
+        description: "interrupt of TIMER_GROUP1, LACT, level"
+        value: 21

--- a/svd/patches/_interrupts.yaml
+++ b/svd/patches/_interrupts.yaml
@@ -124,58 +124,6 @@ SLC:
         description: "interrupt of SLC1, level"
         value: 11
 
-UHCI0:
-  _add:
-    _interrupts:
-      UHCI0_INTR:
-        description: "interrupt of UHCI0, level"
-        value: 12
-
-UHCI1:
-  _add:
-    _interrupts:
-      UHCI1_INTR:
-        description: "interrupt of UHCI1, level"
-        value: 13
-
-TIMG0:
-  _add:
-    _interrupts:
-      TG0_T0_LEVEL_INTR:
-        description: "interrupt of TIMER_GROUP0, TIMER0, level, we would like use EDGE for timer if permission"
-        value: 14
-
-      TG0_T1_LEVEL_INTR:
-        description: "interrupt of TIMER_GROUP0, TIMER1, level, we would like use EDGE for timer if permission"
-        value: 15
-
-      TG0_WDT_LEVEL_INTR:
-        description: "interrupt of TIMER_GROUP0, WATCHDOG, level"
-        value: 16
-
-      TG0_LACT_LEVEL_INTR:
-        description: "interrupt of TIMER_GROUP0, LACT, level"
-        value: 17
-
-TIMG1:
-  _add:
-    _interrupts:
-      TG1_T0_LEVEL_INTR:
-        description: "interrupt of TIMER_GROUP1, TIMER0, level, we would like use EDGE for timer if permission"
-        value: 18
-    
-      TG1_T1_LEVEL_INTR:
-        description: "interrupt of TIMER_GROUP1, TIMER1, level, we would like use EDGE for timer if permission"
-        value: 19
-
-      TG1_WDT_LEVEL_INTR:
-        description: "interrupt of TIMER_GROUP1, WATCHDOG, level"
-        value: 20
-    
-      TG1_LACT_LEVEL_INTR:
-        description: "interrupt of TIMER_GROUP1, LACT, level"
-        value: 21
-
 GPIO:
   _add:
     _interrupts:
@@ -206,34 +154,6 @@ XTENSA:
         description: "interrupt3 generated from a CPU, level"
         value: 27
 
-SPI0:
-  _add:
-    _interrupts:      
-      SPI0_INTR:
-        description: "interrupt of SPI0, level, SPI0 is for Cache Access, do not use this"
-        value: 28
-
-SPI1:
-  _add:
-    _interrupts:      
-      SPI1_INTR:
-        description: "interrupt of SPI1, level, SPI1 is for flash read/write, do not use this"
-        value: 29
-
-SPI2:
-  _add:
-    _interrupts:      
-      SPI2_INTR:
-        description: "interrupt of SPI2, level"
-        value: 30
-
-SPI3:
-  _add:
-    _interrupts:      
-      SPI3_INTR:
-        description: "interrupt of SPI3, level"
-        value: 31
-
 I2S:
   _add:
     _interrupts:      
@@ -244,27 +164,6 @@ I2S:
       I2S1_INTR:
         description: "interrupt of I2S1, level"
         value: 33
-
-UART0:
-  _add:
-    _interrupts:      
-      UART0_INTR:
-        description: "interrupt of UART0, level"
-        value: 34
-
-UART1:
-  _add:
-    _interrupts:      
-      UART1_INTR:
-        description: "interrupt of UART1, level"
-        value: 35
-
-UART2:
-  _add:
-    _interrupts:      
-      UART2_INTR:
-        description: "interrupt of UART2, level"
-        value: 36
 
 SDIO:
   _add:
@@ -279,34 +178,6 @@ ETH:
       ETH_MAC_INTR:
         description: "interrupt of ethernet mac, level"
         value: 38
-
-PWM0:
-  _add:
-    _interrupts:      
-      PWM0_INTR:
-        description: "interrupt of PWM0, level, Reserved"
-        value: 39
-
-PWM1:
-  _add:
-    _interrupts:      
-      PWM1_INTR:
-        description: "interrupt of PWM1, level, Reserved"
-        value: 40
-
-PWM2:
-  _add:
-    _interrupts:      
-      PWM2_INTR:
-        description: "interrupt of PWM2, level"
-        value: 41
-      
-PWM3:
-  _add:
-    _interrupts:      
-      PWM3_INTR:
-        description: "interrupt of PWM3, level"
-        value: 42
 
 LEDC:
   _add:
@@ -350,47 +221,12 @@ PCNT:
         description: "interrupt of pluse count, level"
         value: 48
 
-I2C0:
-  _add:
-    _interrupts:      
-      I2C_EXT0_INTR:
-        description: "interrupt of I2C controller0, level"
-        value: 49
-
-I2C1:
-  _add:
-    _interrupts:      
-      I2C_EXT1_INTR:
-        description: "interrupt of I2C controller1, level"
-        value: 50
-
 RSA:
   _add:
     _interrupts:      
       RSA_INTR:
         description: "interrupt of RSA accelerator, level"
         value: 51
-
-SPI1:
-  _add:
-    _interrupts:      
-      SPI1_DMA_INTR:
-        description: "interrupt of SPI1 DMA, SPI1 is for flash read/write, do not use this"
-        value: 52
-
-SPI2:
-  _add:
-    _interrupts:      
-      SPI2_DMA_INTR:
-        description: "interrupt of SPI2 DMA, level"
-        value: 53
-      
-SPI3:
-  _add:
-    _interrupts:      
-      SPI3_DMA_INTR:
-        description: "interrupt of SPI3 DMA, level"
-        value: 54
       
 WDT:
   _add:
@@ -409,44 +245,6 @@ XTENSA:
       TIMER2_INTR:
         description: "will be cancelled"
         value: 57
-
-TIMG0:
-  _add:
-    _interrupts:
-      TG0_T0_EDGE_INTR:
-        description: "interrupt of TIMER_GROUP0, TIMER0, EDGE"
-        value: 58
-      
-      TG0_T1_EDGE_INTR:
-        description: "interrupt of TIMER_GROUP0, TIMER1, EDGE"
-        value: 59
-      
-      TG0_WDT_EDGE_INTR:
-        description: "interrupt of TIMER_GROUP0, WATCH DOG, EDGE"
-        value: 60
-      
-      TG0_LACT_EDGE_INTR:
-        description: "interrupt of TIMER_GROUP0, LACT, EDGE"
-        value: 61
-      
-TIMG1:
-  _add:
-    _interrupts:      
-      TG1_T0_EDGE_INTR:
-        description: "interrupt of TIMER_GROUP1, TIMER0, EDGE"
-        value: 62
-      
-      TG1_T1_EDGE_INTR:
-        description: "interrupt of TIMER_GROUP1, TIMER1, EDGE"
-        value: 63
-      
-      TG1_WDT_EDGE_INTR:
-        description: "interrupt of TIMER_GROUP1, WATCHDOG, EDGE"
-        value: 64
-      
-      TG1_LACT_EDGE_INTR:
-        description: "interrupt of TIMER_GROUP0, LACT, EDGE"
-        value: 65
 
 XTENSA:
   _add:

--- a/svd/patches/esp32.yaml
+++ b/svd/patches/esp32.yaml
@@ -6,6 +6,7 @@ _include:
   - "_rename_registers.yaml"
   - "_rename_bitfields.yaml"
   - "_interrupts.yaml"
+  # - "_indexed_interrupts.yaml" # currently broken with svdtools, see: https://github.com/esp-rs/esp32/issues/17
 
 _modify:
   PWM:


### PR DESCRIPTION
Remove all indexed peripherals for now, as svdtools dies when trying to parse them. The fix cannot be applied to svdtools as it breaks stm32-rs