### PR TITLE
Workaround for RTC_CNTL_REG which is not created correctly by svd2idf

### DIFF
--- a/svd/patches/_rename_bitfields.yaml
+++ b/svd/patches/_rename_bitfields.yaml
@@ -128,6 +128,9 @@ TIMG:
   "*":
     _strip:
       - TIMG_
+  "RTCCALICFG*":
+    _strip:
+      - RTC_CALI_
 
 UART:
   "*":

--- a/svd/patches/_rtc_cntl.yaml
+++ b/svd/patches/_rtc_cntl.yaml
@@ -1,3 +1,13 @@
+_modify:
+  RTCCNTL:
+    addressBlocks:
+    - offset: 0x0
+      size: 0x6a0
+      usage: RTC CNTL registers
+    - offset: 0x200C6000
+      size: 0x4
+      usage: Internal I2C registers
+
 RTCCNTL:
   CLK_CONF:
     ANA_CLK_RTC_SEL:
@@ -58,3 +68,61 @@ RTCCNTL:
       BIAS_1V15: [5, "Core voltage 1.15V"]
       BIAS_1V20: [6, "Core voltage 1.20V"]
       BIAS_1V25: [7, "Core voltage 1.25V"]
+  _add:
+    APLL:
+      description: APLL I2C Register
+      addressOffset: 0x200C600C
+      size: 32
+      access: read-write
+      resetValue: 0
+      fields:
+          BLOCK:
+              description: Block
+              bitOffset: 0
+              bitWidth: 8
+          ADDR:
+              description: Address
+              bitOffset: 8
+              bitWidth: 8
+          DATA:
+              description: Data
+              bitOffset: 16
+              bitWidth: 8
+          WRITE:
+              description: Write
+              bitOffset: 24
+              bitWidth: 1
+          BUSY:
+              description: Ready
+              bitOffset: 25
+              bitWidth: 1
+    PLL:
+      description: PLL I2C Register
+      addressOffset: 0x200C6010
+      size: 32
+      access: read-write
+      resetValue: 0
+      fields:
+          BLOCK:
+              description: Block
+              bitOffset: 0
+              bitWidth: 8
+          ADDR:
+              description: Address
+              bitOffset: 8
+              bitWidth: 8
+          DATA:
+              description: Data
+              bitOffset: 16
+              bitWidth: 8
+          WRITE:
+              description: Write
+              bitOffset: 24
+              bitWidth: 1
+          BUSY:
+              description: Ready
+              bitOffset: 25
+              bitWidth: 1
+
+
+

--- a/svd/patches/_rtc_cntl.yaml
+++ b/svd/patches/_rtc_cntl.yaml
@@ -58,7 +58,7 @@ RTCCNTL:
       T800ns: [5, "800ns"]
       T1600ns: [6, "1600ns"]
       T3200ns: [7, "3200ns"]
-  BIAS_CONF:
+  CNTL:
     "*DBIAS_*":
       BIAS_0V90: [0, "Core voltage 0.90V"]
       BIAS_0V95: [1, "Core voltage 0.95V"]
@@ -69,6 +69,53 @@ RTCCNTL:
       BIAS_1V20: [6, "Core voltage 1.20V"]
       BIAS_1V25: [7, "Core voltage 1.25V"]
   _add:
+    CNTL:
+      description: RTC Control Register
+      addressOffset: 0x7c
+      size: 32
+      access: read-write
+      resetValue: 0
+      fields:
+        FORCE_PU:
+          description: "Force RTC power up"
+          bitOffset: 31
+          bitWidth: 1
+        FORCE_PD:
+          description: "Force RTC power down (decrease voltage to 0.8V or lower)"
+          bitOffset: 30
+          bitWidth: 1
+        FORCE_DBOOST_PU:
+          description: "Force DBOOST power up"
+          bitOffset: 29
+          bitWidth: 1
+        FORCE_DBOOST_PD:
+          description: "Force DBOOST power down"
+          bitOffset: 28
+          bitWidth: 1
+        DBIAS_WAK:
+          description: "RTC DBIAS during wakeup"
+          bitOffset: 25
+          bitWidth: 3
+        DBIAS_SLP:
+          description: "RTC DBIAS during sleep"
+          bitOffset: 22
+          bitWidth: 3          
+        SCK_DCAP:
+          description: "150kHz oscillator tuning"
+          bitOffset: 14
+          bitWidth: 8
+        DIG_DBIAS_WAK:
+          description: "DBIAS during wakeup"
+          bitOffset: 11
+          bitWidth: 3
+        DIG_DBIAS_SLP:
+          description: "DBIAS during wakeup"
+          bitOffset: 8
+          bitWidth: 3
+        SCK_DCAP_FORCE:
+          description: "150kHz tuning force"
+          bitOffset: 7
+          bitWidth: 1
     APLL:
       description: APLL I2C Register
       addressOffset: 0x200C600C
@@ -76,26 +123,26 @@ RTCCNTL:
       access: read-write
       resetValue: 0
       fields:
-          BLOCK:
-              description: Block
-              bitOffset: 0
-              bitWidth: 8
-          ADDR:
-              description: Address
-              bitOffset: 8
-              bitWidth: 8
-          DATA:
-              description: Data
-              bitOffset: 16
-              bitWidth: 8
-          WRITE:
-              description: Write
-              bitOffset: 24
-              bitWidth: 1
-          BUSY:
-              description: Ready
-              bitOffset: 25
-              bitWidth: 1
+        BLOCK:
+            description: Block
+            bitOffset: 0
+            bitWidth: 8
+        ADDR:
+            description: Address
+            bitOffset: 8
+            bitWidth: 8
+        DATA:
+            description: Data
+            bitOffset: 16
+            bitWidth: 8
+        WRITE:
+            description: Write
+            bitOffset: 24
+            bitWidth: 1
+        BUSY:
+            description: Ready
+            bitOffset: 25
+            bitWidth: 1
     PLL:
       description: PLL I2C Register
       addressOffset: 0x200C6010
@@ -103,26 +150,24 @@ RTCCNTL:
       access: read-write
       resetValue: 0
       fields:
-          BLOCK:
-              description: Block
-              bitOffset: 0
-              bitWidth: 8
-          ADDR:
-              description: Address
-              bitOffset: 8
-              bitWidth: 8
-          DATA:
-              description: Data
-              bitOffset: 16
-              bitWidth: 8
-          WRITE:
-              description: Write
-              bitOffset: 24
-              bitWidth: 1
-          BUSY:
-              description: Ready
-              bitOffset: 25
-              bitWidth: 1
-
-
-
+        BLOCK:
+            description: Block
+            bitOffset: 0
+            bitWidth: 8
+        ADDR:
+            description: Address
+            bitOffset: 8
+            bitWidth: 8
+        DATA:
+            description: Data
+            bitOffset: 16
+            bitWidth: 8
+        WRITE:
+            description: Write
+            bitOffset: 24
+            bitWidth: 1
+        BUSY:
+            description: Ready
+            bitOffset: 25
+            bitWidth: 1
+  

--- a/svd/patches/_timg.yaml
+++ b/svd/patches/_timg.yaml
@@ -1,0 +1,6 @@
+TIMG:
+  RTCCALICFG:
+    CLK_SEL:
+      RTC_MUX: [0, "Select RTC slow clock"]
+      CK8M_D256: [1, "Internal 8 MHz RC oscillator, divided by 256"]
+      XTAL32K: [2, "Select XTAL_32K"]

--- a/svd/patches/esp32.yaml
+++ b/svd/patches/esp32.yaml
@@ -9,6 +9,7 @@ _include:
   - "_rtc_cntl.yaml"
   - "_dport.yaml"
   - "_interrupts.yaml"
+  - "_timg.yaml"
 #  - "_indexed_interrupts.yaml" # currently broken with svdtools, see: https://github.com/esp-rs/esp32/issues/17
 
 _modify:


### PR DESCRIPTION
Workaround for RTC_CNTL_REG which is not created correctly by svd2idf and added some field definitions for TIMG.
