### PR TITLE
Added field to FIFO registers, for cortex-m debug to work

### DIFF
--- a/svd/patches/_uart.yaml
+++ b/svd/patches/_uart.yaml
@@ -15,11 +15,21 @@ UART:
       addressOffset: 0x200C0000
       size: 8
       access: write-only
+      fields:
+          DATA:
+            description: TX FIFO Data
+            bitOffset: 0
+            bitWidth: 8
     RX_FIFO:
       description: UART_RX_FIFO
       addressOffset: 0x00
       size: 8
       access: read-only
+      fields:
+          DATA:
+            description: TX FIFO Data
+            bitOffset: 0
+            bitWidth: 8
   STATUS:
     UART_ST_UTX_OUT:
       TX_IDLE: [0, "TX_IDLE"]


### PR DESCRIPTION
The cortex-m debugger could not load the SVD file when no fields were defined on these registers.

(BTW it does also not work with the _interrupts.yaml file, so in my local copy I have commented this out for the time being.)