### PR TITLE
Changed to split xtensa-lx6-rt, add AES and add output svd to repo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "esp32"
 version = "0.4.0"
-authors = ["Scott Mabin <scott@mabez.dev>"]
+authors = ["Scott Mabin <scott@mabez.dev>", "Arjan Mels <arjan@mels.email>"]
 edition = "2018"
 readme = "README.md"
 repository = "https://github.com/esp-rs/esp32"
@@ -23,7 +23,8 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 bare-metal = "0.2"
 vcell = "0.1"
-xtensa-lx6-rt = "0.1.0"
+xtensa-lx6 = "0.1.0"
+xtensa-lx6-rt = "0.2.0"
 
 [features]
 default=["rt"]

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ patch:
 	mv svd/$(BASE).patched svd/$(OUTPUT)
 
 generate:
-	svd2rust --target esp32 -i svd/$(OUTPUT)
+	svd2rust --target xtensalx6 -i svd/$(OUTPUT)
 
 form:
 	form -i lib.rs -o src/

--- a/svd/esp32.svd
+++ b/svd/esp32.svd
@@ -20,7 +20,28 @@
                 <size>0x00000000</size>
                 <usage>registers</usage>
             </addressBlock>
-            <registers />
+            <registers><register><name>START</name><fields><field><name>START</name><description>Write 1 to start AES operation</description><bitOffset>0</bitOffset><bitWidth>1</bitWidth></field>
+            </fields><description>AES Start</description><size>32</size><addressOffset>0</addressOffset><access>write-only</access><resetValue>0</resetValue></register>
+        <register><name>IDLE</name><fields><field><name>IDLE</name><description>0 when AES is busy, 1 otherwise</description><bitOffset>0</bitOffset><bitWidth>1</bitWidth></field>
+            </fields><description>AES Idle</description><size>32</size><addressOffset>4</addressOffset><access>read-only</access><resetValue>1</resetValue></register>
+        <register><name>MODE</name><fields><field><name>MODE</name><description>Selects AES accelerator mode</description><bitOffset>0</bitOffset><bitWidth>3</bitWidth><enumeratedValues><name>MODE</name><usage>read-write</usage><enumeratedValue><name>AES128_ENCRYPT</name><description>AES-128 Encryption</description><value>0</value></enumeratedValue><enumeratedValue><name>AES192_ENCRYPT</name><description>AES-192 Encryption</description><value>1</value></enumeratedValue><enumeratedValue><name>AES256_ENCRYPT</name><description>AES-256 Encryption</description><value>2</value></enumeratedValue><enumeratedValue><name>AES128_DECRYPT</name><description>AES-128 Decryption</description><value>4</value></enumeratedValue><enumeratedValue><name>AES192_DECRYPT</name><description>AES-192 Decryption</description><value>5</value></enumeratedValue><enumeratedValue><name>AES256_DECRYPT</name><description>AES-256 Decryption</description><value>6</value></enumeratedValue></enumeratedValues>
+            </field>
+            </fields><description>AES Mode</description><size>32</size><addressOffset>8</addressOffset><resetValue>0</resetValue></register>
+        <register><name>KEY_0</name><fields /><description>AES Key material 0</description><size>32</size><addressOffset>16</addressOffset><resetValue>0</resetValue></register>
+        <register><name>KEY_1</name><fields /><description>AES Key material 1</description><size>32</size><addressOffset>20</addressOffset><resetValue>0</resetValue></register>
+        <register><name>KEY_2</name><fields /><description>AES Key material 2</description><size>32</size><addressOffset>24</addressOffset><resetValue>0</resetValue></register>
+        <register><name>KEY_3</name><fields /><description>AES Key material 3</description><size>32</size><addressOffset>28</addressOffset><resetValue>0</resetValue></register>
+        <register><name>KEY_4</name><fields /><description>AES Key material 4</description><size>32</size><addressOffset>32</addressOffset><resetValue>0</resetValue></register>
+        <register><name>KEY_5</name><fields /><description>AES Key material 5</description><size>32</size><addressOffset>36</addressOffset><resetValue>0</resetValue></register>
+        <register><name>KEY_6</name><fields /><description>AES Key material 6</description><size>32</size><addressOffset>40</addressOffset><resetValue>0</resetValue></register>
+        <register><name>KEY_7</name><fields /><description>AES Key material 7</description><size>32</size><addressOffset>44</addressOffset><resetValue>0</resetValue></register>
+        <register><name>TEXT_0</name><fields /><description>Plaintext and ciphertext register 0</description><size>32</size><addressOffset>48</addressOffset><resetValue>0</resetValue></register>
+        <register><name>TEXT_1</name><fields /><description>Plaintext and ciphertext register 1</description><size>32</size><addressOffset>52</addressOffset><resetValue>0</resetValue></register>
+        <register><name>TEXT_2</name><fields /><description>Plaintext and ciphertext register 2</description><size>32</size><addressOffset>56</addressOffset><resetValue>0</resetValue></register>
+        <register><name>TEXT_3</name><fields /><description>Plaintext and ciphertext register 3</description><size>32</size><addressOffset>60</addressOffset><resetValue>0</resetValue></register>
+        <register><name>ENDIAN</name><fields><field><name>MODE</name><description>Select AES endian mode</description><bitOffset>0</bitOffset><bitWidth>6</bitWidth></field>
+            </fields><description>AES Endian selection</description><size>32</size><addressOffset>64</addressOffset><resetValue>63</resetValue></register>
+        </registers>
         </peripheral>
         <peripheral>
             <name>HINF</name>

--- a/svd/patches/_aes.yaml
+++ b/svd/patches/_aes.yaml
@@ -1,0 +1,116 @@
+
+AES:
+  _add:
+    START:
+      description: AES Start
+      size: 32
+      addressOffset: 0x0
+      access: write-only
+      resetValue: 0x00000000
+      fields:
+        START:
+          description: Write 1 to start AES operation
+          bitOffset: 0
+          bitWidth: 1
+    IDLE:
+      description: AES Idle
+      size: 32
+      addressOffset: 0x4
+      access: read-only
+      resetValue: 0x00000001
+      fields:
+        IDLE:
+          description: 0 when AES is busy, 1 otherwise
+          bitOffset: 0
+          bitWidth: 1
+    MODE:
+      description: AES Mode
+      size: 32
+      addressOffset: 0x8
+      resetValue: 0x00000000
+      fields:
+        MODE:
+          description: Selects AES accelerator mode
+          bitOffset: 0
+          bitWidth: 3
+    KEY_0:
+      description: AES Key material 0
+      size: 32
+      addressOffset: 0x10
+      resetValue: 0x00000000
+    KEY_1:
+      description: AES Key material 1
+      size: 32
+      addressOffset: 0x14
+      resetValue: 0x00000000
+    KEY_2:
+      description: AES Key material 2
+      size: 32
+      addressOffset: 0x18
+      resetValue: 0x00000000
+    KEY_3:
+      description: AES Key material 3
+      size: 32
+      addressOffset: 0x1c
+      resetValue: 0x00000000
+    KEY_4:
+      description: AES Key material 4
+      size: 32
+      addressOffset: 0x20
+      resetValue: 0x00000000
+    KEY_5:
+      description: AES Key material 5
+      size: 32
+      addressOffset: 0x24
+      resetValue: 0x00000000
+    KEY_6:
+      description: AES Key material 6
+      size: 32
+      addressOffset: 0x28
+      resetValue: 0x00000000
+    KEY_7:
+      description: AES Key material 7
+      size: 32
+      addressOffset: 0x2c
+      resetValue: 0x00000000
+    
+    TEXT_0:
+      description: Plaintext and ciphertext register 0
+      size: 32
+      addressOffset: 0x30
+      resetValue: 0x00000000
+    TEXT_1:
+      description: Plaintext and ciphertext register 1
+      size: 32
+      addressOffset: 0x34
+      resetValue: 0x00000000
+    TEXT_2:
+      description: Plaintext and ciphertext register 2
+      size: 32
+      addressOffset: 0x38
+      resetValue: 0x00000000
+    TEXT_3:
+      description: Plaintext and ciphertext register 3
+      size: 32
+      addressOffset: 0x3c
+      resetValue: 0x00000000
+
+    ENDIAN:
+      description: AES Endian selection
+      size: 32
+      addressOffset: 0x40
+      resetValue: 0x0000003f
+      fields:
+        MODE:
+          description: Select AES endian mode
+          bitOffset: 0
+          bitWidth: 6
+
+  MODE:
+    MODE:
+      AES128_ENCRYPT: [0, "AES-128 Encryption"]
+      AES192_ENCRYPT: [1, "AES-192 Encryption"]
+      AES256_ENCRYPT: [2, "AES-256 Encryption"]
+      AES128_DECRYPT: [4, "AES-128 Decryption"]
+      AES192_DECRYPT: [5, "AES-192 Decryption"]
+      AES256_DECRYPT: [6, "AES-256 Decryption"]

--- a/svd/patches/esp32.yaml
+++ b/svd/patches/esp32.yaml
@@ -2,6 +2,7 @@ _svd: ../esp32.base.svd
 
 
 _include:
+  - "_aes.yaml"
   - "_uart.yaml"
   - "_io_mux.yaml"
   - "_rename_registers.yaml"

--- a/svd/patches/esp32.yaml
+++ b/svd/patches/esp32.yaml
@@ -12,7 +12,7 @@ _include:
   - "_interrupts.yaml"
   - "_timg.yaml"
 #  - "_indexed_interrupts.yaml" # currently broken with svdtools, see: https://github.com/esp-rs/esp32/issues/17
-  - "_indexed_interrupts_flat.yaml" # currently broken with svdtools, see: https://github.com/esp-rs/esp32/issues/17
+  - "_indexed_interrupts_flat.yaml"
 
 _modify:
   PWM:


### PR DESCRIPTION
- Updated for split xtensa-lx6-rt
- Added AES peripheral (not included in header files), because it causes issues with new svd parser for svd2rust
- Added output svd file to repo (remove from .gitignore) because it is used in testing svd2rust.