### PR TITLE
Updated cargo.toml to latest xtensa-lx6/xtensa-lx6-rt crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esp32"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Scott Mabin <scott@mabez.dev>", "Arjan Mels <arjan@mels.email>"]
 edition = "2018"
 readme = "README.md"
@@ -23,10 +23,10 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 bare-metal = "0.2"
 vcell = "0.1"
-xtensa-lx6 = "0.1.0"
-xtensa-lx6-rt = "0.2.0"
+xtensa-lx6 = "0.2.0"
+xtensa-lx6-rt = { version = "0.3.0", optional = true }
 
 [features]
 default=["rt"]
 
-rt=[]
+rt=["xtensa-lx6-rt"]


### PR DESCRIPTION
Need to bring this inline with latest updates on xtensa-lx6, otherwise results in version conflicts when using esp32-hal.