### PR TITLE
Update esp32.base.svd to correct the name field

### DIFF
--- a/svd/esp32.base.svd
+++ b/svd/esp32.base.svd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <device xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.0" xs:noNamespaceSchemaLocation="CMSIS-SVD_Schema_1.0.xsd">
-    <name>Espressif</name>
+    <name>esp32</name>
     <version>1.0</version>
     <width>32</width>
     <cpu>


### PR DESCRIPTION
See: https://github.com/MabezDev/idf2svd/pull/17

This corrects the first `<name>` field, which was incorrect. When I generate a new esp32.base.svd, there are many more changes but I picked just this one as I don't know where all the other changes are coming from (maybe updates to idf2svd since esp32.base.svd was created?).