### PR TITLE
Xtensa bump & SVD regeneration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esp32"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Scott Mabin <scott@mabez.dev>", "Arjan Mels <arjan@mels.email>"]
 edition = "2018"
 readme = "README.md"
@@ -21,11 +21,11 @@ include = [
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-bare-metal = "0.2"
+bare-metal = "1.0"
 vcell = "0.1"
-xtensa-lx = "0.3.0"
-xtensa-lx-rt = { version = "0.5.0", optional = true }
+xtensa-lx = "0.4.0"
+xtensa-lx-rt = { version = "0.7.0", optional = true }
 
 [features]
-default=[]
-rt=["xtensa-lx-rt"]
+default=["xtensa-lx/lx6"]
+rt=["xtensa-lx-rt/lx6"]

--- a/Makefile
+++ b/Makefile
@@ -25,4 +25,4 @@ fmt:
 
 build:
 	cargo clean
-	cargo xbuild --target xtensa-esp32-none-elf
+	cargo +esp-dev build --target xtensa-esp32-none-elf -Zbuild-std=core

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Required dependencies:
 
 - [form](https://crates.io/crates/form)
 - [svd](https://github.com/stm32-rs/svdtools)
-- [svd2rust](https://github.com/rust-embedded/svd2rust)
+- [svd2rust](https://github.com/rust-embedded/svd2rust) - NOTE: Currently requires a `svd2rust` with this PR included: https://github.com/rust-embedded/svd2rust/pull/536
 
 ```
 $ make

--- a/svd/esp32.svd
+++ b/svd/esp32.svd
@@ -1,4 +1,4 @@
-<device xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.0" xsi:noNamespaceSchemaLocation="CMSIS-SVD_Schema_1.0.xsd">
+<device xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.0" xs:noNamespaceSchemaLocation="CMSIS-SVD_Schema_1.0.xsd">
     <name>esp32</name>
     <version>1.0</version>
     <cpu>
@@ -1480,7 +1480,7 @@
                     <dimIncrement>0x4</dimIncrement>
                     <dimIndex>0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15</dimIndex>
                     <name>W%s</name>
-                    <description>SPI_W0</description>
+                    <description>SPI_W%s</description>
                     <addressOffset>0x80</addressOffset>
                     <size>32</size>
                     <resetValue>0x00000000</resetValue>
@@ -9070,7 +9070,7 @@
                     <dimIncrement>0x4</dimIncrement>
                     <dimIndex>0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39</dimIndex>
                     <name>PIN%s</name>
-                    <description>GPIO_PIN0</description>
+                    <description>GPIO_PIN%s</description>
                     <addressOffset>0x88</addressOffset>
                     <size>32</size>
                     <resetValue>0x00000000</resetValue>
@@ -9150,7 +9150,7 @@
                     <dimIncrement>0x4</dimIncrement>
                     <dimIndex>0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,162,163,164,165,166,167,168,169,170,171,172,173,174,175,176,177,178,179,180,181,182,183,184,185,186,187,188,189,190,191,192,193,194,195,196,197,198,199,200,201,202,203,204,205,206,207,208,209,210,211,212,213,214,215,216,217,218,219,220,221,222,223,224,225,226,227,228,229,230,231,232,233,234,235,236,237,238,239,240,241,242,243,244,245,246,247,248,249,250,251,252,253,254,255</dimIndex>
                     <name>FUNC%s_IN_SEL_CFG</name>
-                    <description>GPIO_FUNC0_IN_SEL_CFG</description>
+                    <description>GPIO_FUNC%s_IN_SEL_CFG</description>
                     <addressOffset>0x130</addressOffset>
                     <size>32</size>
                     <resetValue>0x00000000</resetValue>
@@ -9177,7 +9177,7 @@
                     <dimIncrement>0x4</dimIncrement>
                     <dimIndex>0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39</dimIndex>
                     <name>FUNC%s_OUT_SEL_CFG</name>
-                    <description>GPIO_FUNC0_OUT_SEL_CFG</description>
+                    <description>GPIO_FUNC%s_OUT_SEL_CFG</description>
                     <addressOffset>0x530</addressOffset>
                     <size>32</size>
                     <resetValue>0x00000000</resetValue>
@@ -20770,7 +20770,7 @@
                     <dimIncrement>0x4</dimIncrement>
                     <dimIndex>0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17</dimIndex>
                     <name>PIN%s</name>
-                    <description>RTC_GPIO_PIN0</description>
+                    <description>RTC_GPIO_PIN%s</description>
                     <addressOffset>0x28</addressOffset>
                     <size>32</size>
                     <resetValue>0x00000000</resetValue>
@@ -42028,6 +42028,20 @@
         <peripheral derivedFrom="UART">
             <name>UART0</name>
             <baseAddress>0x3ff40000</baseAddress>
+        </peripheral>
+        <peripheral>
+            <name>RNG</name>
+            <description>True Random Number Generator</description>
+            <baseAddress>1073172804</baseAddress>
+            <registers>
+                <register>
+                    <name>RNG_DATA</name>
+                    <description>Random Number Data</description>
+                    <addressOffset>0</addressOffset>
+                    <size>32</size>
+                    <access>read-only</access>
+                </register>
+            </registers>
         </peripheral>
         <peripheral>
             <name>XTENSA_INTERNAL</name>


### PR DESCRIPTION
Requires generating with a version of `svd2rust` with this patch: https://github.com/rust-embedded/svd2rust/pull/536.