### PR TITLE
Make addressBlock usage elements follow the specification

### DIFF
--- a/svd/esp32.svd
+++ b/svd/esp32.svd
@@ -17017,12 +17017,12 @@
             <addressBlock>
                 <offset>0</offset>
                 <size>1696</size>
-                <usage>RTC CNTL registers</usage>
+                <usage>registers</usage>
             </addressBlock>
             <addressBlock>
                 <offset>537681920</offset>
                 <size>4</size>
-                <usage>Internal I2C registers</usage>
+                <usage>registers</usage>
             </addressBlock>
             <interrupt>
                 <name>RTC_CORE_INTR</name>
@@ -35074,12 +35074,12 @@
             <addressBlock>
                 <offset>0</offset>
                 <size>1024</size>
-                <usage>UART registers</usage>
+                <usage>registers</usage>
             </addressBlock>
             <addressBlock>
                 <offset>537657344</offset>
                 <size>4</size>
-                <usage>TX FIFO</usage>
+                <usage>buffer</usage>
             </addressBlock>
             <interrupt>
                 <name>UART0_INTR</name>

--- a/svd/patches/_rtc_cntl.yaml
+++ b/svd/patches/_rtc_cntl.yaml
@@ -3,10 +3,10 @@ _modify:
     addressBlocks:
     - offset: 0x0
       size: 0x6a0
-      usage: RTC CNTL registers
+      usage: registers
     - offset: 0x200C6000
       size: 0x4
-      usage: Internal I2C registers
+      usage: registers
 
 RTCCNTL:
   CLK_CONF:

--- a/svd/patches/_uart.yaml
+++ b/svd/patches/_uart.yaml
@@ -3,10 +3,10 @@ _modify:
     addressBlocks:
     - offset: 0x0
       size: 0x400
-      usage: UART registers
+      usage: registers
     - offset: 0x200C0000
       size: 0x4
-      usage: TX FIFO
+      usage: buffer
 
 UART:
   _add:


### PR DESCRIPTION
The [CMSIS-SVD specification](https://www.keil.com/pack/doc/CMSIS/SVD/html/elem_peripherals.html#elem_addressBlock) for `<addressBlock/>` elements states that 'usage' must be one of `registers`, `buffer`, or `reserved`.

This is in response to #46.